### PR TITLE
Case insensitive search

### DIFF
--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -52,6 +52,8 @@ jobs:
     - name: Search
       run: |
         fpm run
+        fpm run -- FORTRAN
+        fpm run -- PARSER
         fpm run -- hash
         fpm run -- pixel -V
         fpm run -- -V

--- a/app/main.f90
+++ b/app/main.f90
@@ -465,8 +465,12 @@ integer function indexi(string, substring) result(r)
         t = substring(1:1)
         ipos = 1
 
-        do while (ipos <= len(substring))
+        do while (.true.)
             if (uchar(s) .ne. uchar(t)) then
+                exit
+            end if
+
+            if ((opos+ipos) > len(string) .or. (ipos+1) > len(substring)) then
                 exit
             end if
 
@@ -475,7 +479,7 @@ integer function indexi(string, substring) result(r)
             ipos = ipos + 1
         end do
 
-        if (ipos .eq. len(substring) + 1) then
+        if (ipos .eq. len(substring)) then
             r = opos
             exit
         end if

--- a/app/main.f90
+++ b/app/main.f90
@@ -347,8 +347,8 @@ subroutine table_search(tbl, pattern)
         call table_get_package(tbl, fhash_key(i), pkg, r)
 
         if (.not. r0) then
-            r1 = index(pkg%name, pattern) > 0
-            r2 = index(pkg%description, pattern) > 0
+            r1 = indexi(pkg%name, pattern) > 0
+            r2 = indexi(pkg%description, pattern) > 0
         end if
 
         if (r0 .or. r1 .or. r2) then
@@ -376,8 +376,8 @@ subroutine table_info(tbl, pattern)
         call table_get_package(tbl, fhash_key(i), pkg, r)
 
         if (.not. r0) then
-            r1 = index(pkg%name, pattern) > 0
-            r2 = index(pkg%description, pattern) > 0
+            r1 = indexi(pkg%name, pattern) > 0
+            r2 = indexi(pkg%description, pattern) > 0
         end if
 
         if (r0 .or. r1 .or. r2) then
@@ -439,5 +439,63 @@ subroutine table_info(tbl, pattern)
     end do
 
 end subroutine
+
+!
+! Function indexi
+!
+! Find the position of substring within string ignoring case.
+! If substring is not present in string, zero is returned.
+! Status: experimental
+!
+integer function indexi(string, substring) result(r)
+    character(len=*), intent(in) :: string
+    character(len=*), intent(in) :: substring
+    character(len=1) :: s
+    character(len=1) :: t
+    integer :: opos ! outer position
+    integer :: ipos ! inner position
+
+    r = 0
+    opos = 1
+
+    if (len(substring) .eq. 0 .or. len(substring) > len(string)) return
+
+    do while (opos <= len(string))
+        s = string(opos:opos)
+        t = substring(1:1)
+        ipos = 1
+
+        do while (ipos <= len(substring))
+            if (uchar(s) .ne. uchar(t)) then
+                exit
+            end if
+
+            s = string(opos+ipos:opos+ipos)
+            t = substring(ipos+1:ipos+1)
+            ipos = ipos + 1
+        end do
+
+        if (ipos .eq. len(substring) + 1) then
+            r = opos
+            exit
+        end if
+
+        opos = opos + 1
+    end do
+end function
+
+integer function uchar(c) result(r)
+    character(len=1), intent(in) :: c
+    integer :: uc
+
+    uc = ichar(c)
+
+    ! 'a' = 97, 'z' = 122
+    if (uc >= 97 .and. uc <= 122) then
+        r = uc - 32
+    else
+        r = uc
+    end if
+end function
 
 end program main


### PR DESCRIPTION
CI fails

```
stdlib : null
At line 473 of file app/main.f90
Fortran runtime error: Substring out of bounds: upper bound (9) of 'string' exceeds string length (8)
```