### PR TITLE
Use HEAD to reference tip of default branch

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -16,7 +16,7 @@ integer :: loop
 
 ! Remote registry file
 character(len=*), parameter :: registry_url =&
-    'https://github.com/fortran-lang/fpm-registry/raw/master/index.json'
+    'https://github.com/fortran-lang/fpm-registry/raw/HEAD/index.json'
 
 character(len=:), allocatable :: alternate_registry_url
 character(len=:), allocatable :: remote_registry_url


### PR DESCRIPTION
This way fpm-search won't be impacted by https://github.com/fortran-lang/fpm-registry/issues/52